### PR TITLE
fix email_content type

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -152,7 +152,14 @@ function plugin_protocolsmanager_install() {
 		
 		$DB->queryOrDie($query, $DB->error());
 	}
-	
+
+		//update email_content field
+	if (!$DB->FieldExists('glpi_plugin_protocolsmanager_emailconfig', 'email_content')) {
+
+		$query = "ALTER TABLE glpi_plugin_protocolsmanager_emailconfig MODIFY COLUMN email_content TEXT";
+
+		$DB->queryOrDie($query, $DB->error());
+	}
 	
 	if (!$DB->tableExists('glpi_plugin_protocolsmanager_emailconfig')) {
 		
@@ -160,7 +167,7 @@ function plugin_protocolsmanager_install() {
 					id INT(11) NOT NULL auto_increment,
 					tname varchar(255),
 					send_user int(2),
-					email_content varchar(255),
+					email_content text,
 					email_subject varchar(255),
 					email_footer varchar(255),
 					recipients varchar(255),


### PR DESCRIPTION
email_content is created with field type varchar(255), this limits the email text and additional text is cut off.
changed email_content to be created as text type and update field for existing dbs.